### PR TITLE
fix string helpers for laravel 6.x

### DIFF
--- a/src/Http/Services/Settings.php
+++ b/src/Http/Services/Settings.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Cloudstudio\ResourceGenerator\Http\Services;
+use Illuminate\Support\Str;
 
 class Settings
 {
@@ -119,7 +120,7 @@ class Settings
      */
     private function setValue($name, $value)
     {
-        if (is_string($value) && str_contains($value, '\\')) {
+        if (is_string($value) && Str::contains($value, '\\')) {
             $value = str_replace('\\', '\\\\', $value);
         }
         $this->settings->{$name}->value = $value;


### PR DESCRIPTION
I'm unable to save settings.

exception: "Symfony\Component\Debug\Exception\FatalThrowableError"
file: "/home/uwoffertes/web/uwoffertes.be/public_html/latest/vendor/cloudstudio/resource-generator/src/Http/Services/Settings.php"
line: 122
message: "Call to undefined function Cloudstudio\ResourceGenerator\Http\Services\str_contains()"